### PR TITLE
Fix splitscreen and limb attaching errors

### DIFF
--- a/VoidWanderers.rte/Items/AttachOnCollision.lua
+++ b/VoidWanderers.rte/Items/AttachOnCollision.lua
@@ -12,7 +12,7 @@ function OnCollideWithMO(self, mo, rootMO)
 		and self:GetNumberValue("Carriable") > 1
 		and mo
 		and IsAHuman(mo)
-		and CF_AttemptReplaceLimb(self, ToAHuman(mo))
+		and CF_AttemptReplaceLimb(ToAHuman(mo), self)
 	then
 		self.attachSound:Play(self.Pos)
 		self.ToDelete = true

--- a/VoidWanderers.rte/Items/AttachOnCollision.lua
+++ b/VoidWanderers.rte/Items/AttachOnCollision.lua
@@ -29,7 +29,7 @@ function OnCollideWithTerrain(self, terrainID)
 		local mo = MovableMan:GetMOFromID(
 			SceneMan:CastMORay(self.Pos, self.Vel.Normalized, self.ID, Activity.NOTEAM, rte.airID, true, 1)
 		)
-		if mo and IsAHuman(mo:GetRootParent()) and CF_AttemptReplaceLimb(self, ToAHuman(mo:GetRootParent())) then
+		if mo and IsAHuman(mo:GetRootParent()) and CF_AttemptReplaceLimb(ToAHuman(mo:GetRootParent()), self) then
 			self.attachSound:Play(self.Pos)
 			self.ToDelete = true
 		end

--- a/VoidWanderers.rte/Items/Limb.lua
+++ b/VoidWanderers.rte/Items/Limb.lua
@@ -1,3 +1,5 @@
+require("Scripts/Lib_Generic")
+
 function Create(self)
 	self.attachSound = CreateSoundContainer(
 		self:StringValueExists("AttachSound") and self:GetStringValue("AttachSound") or "Robot Stride"
@@ -25,7 +27,7 @@ function Update(self)
 			if
 				actor
 				and IsAHuman(actor:GetRootParent())
-				and CF_AttemptReplaceLimb(self, ToAHuman(actor:GetRootParent()))
+				and CF_AttemptReplaceLimb(ToAHuman(actor:GetRootParent()), self)
 			then
 				ToAHuman(actor:GetRootParent()):FlashWhite(50)
 				self.attachSound:Play(self.Pos)
@@ -39,89 +41,4 @@ function Update(self)
 	else
 		self.wasActivated = false
 	end
-end
-
-function CF_AttemptReplaceLimb(self, actor)
-	local j = 0
-	local isArm = string.find(self.PresetName, " Arm")
-	local isLeg = string.find(self.PresetName, " Leg")
-	local isHead = string.find(self.PresetName, " Head")
-	local limbName = self:StringValueExists("LimbName") and self:GetStringValue("LimbName") or self.PresetName
-	if isArm then
-		j = not actor.FGArm and 1 or (not actor.BGArm and 2 or j)
-	elseif isLeg then
-		j = not actor.FGLeg and 3 or (not actor.BGLeg and 4 or j)
-	elseif isHead and actor.Head == nil then
-		j = 5
-	end
-	if j ~= 0 then
-		local reference = CreateAHuman(actor:GetModuleAndPresetName())
-		local referenceLimb
-		if j == 1 then
-			referenceLimb = reference.FGArm
-		elseif j == 2 then
-			referenceLimb = reference.BGArm
-		elseif j == 3 then
-			referenceLimb = reference.FGLeg
-		elseif j == 4 then
-			referenceLimb = reference.BGLeg
-		elseif j == 5 then
-			referenceLimb = reference.Head
-		end
-		local newLimb
-		if isArm then
-			newLimb = CreateArm(limbName .. (j == 1 and " FG" or " BG"))
-		elseif isLeg then
-			newLimb = CreateLeg(limbName .. (j == 3 and " FG" or " BG"))
-		else
-			newLimb = self:Clone() --(limbName);
-		end
-		if newLimb then
-			if referenceLimb then
-				newLimb.ParentOffset = referenceLimb.ParentOffset
-				local woundName = referenceLimb:GetEntryWoundPresetName()
-				if woundName ~= "" then
-					newLimb.ParentBreakWound = CreateAEmitter(woundName)
-				end
-			end
-			for wound in newLimb.Wounds do
-				if
-					math.floor(wound.ParentOffset.X - newLimb.JointOffset.X + 0.5) == 0
-					and math.floor(wound.ParentOffset.Y - newLimb.JointOffset.Y + 0.5) == 0
-				then
-					for em in wound.Emissions do
-						em.ParticlesPerMinute = 0
-					end
-					wound.Scale = wound.Scale * 0.7
-				end
-			end
-			if j == 1 then
-				actor.FGArm = newLimb
-			elseif j == 2 then
-				actor.BGArm = newLimb
-			elseif j == 3 then
-				actor.FGLeg = newLimb
-			elseif j == 4 then
-				actor.BGLeg = newLimb
-			elseif j == 5 then
-				actor.Head = newLimb
-			end
-			for wound in actor.Wounds do
-				if
-					math.floor(wound.ParentOffset.X - newLimb.ParentOffset.X + 0.5) == 0
-					and math.floor(wound.ParentOffset.Y - newLimb.ParentOffset.Y + 0.5) == 0
-				then
-					for em in wound.Emissions do
-						em.ParticlesPerMinute = 0
-					end
-					wound.Scale = wound.Scale * 0.7
-				end
-			end
-			self:RemoveNumberValue("Carriable")
-		else
-			j = 0
-		end
-		DeleteEntity(reference)
-	end
-	return j ~= 0
 end

--- a/VoidWanderers.rte/Scripts/Lib_Generic.lua
+++ b/VoidWanderers.rte/Scripts/Lib_Generic.lua
@@ -1209,6 +1209,93 @@ end
 -----------------------------------------------------------------------------------------
 --
 -----------------------------------------------------------------------------------------
+function CF_AttemptReplaceLimb(actor, limb)
+	local j = 0
+	local isArm = string.find(limb.PresetName, " Arm")
+	local isLeg = string.find(limb.PresetName, " Leg")
+	local isHead = string.find(limb.PresetName, " Head")
+	local limbName = limb:StringValueExists("LimbName") and limb:GetStringValue("LimbName") or limb.PresetName
+	if isArm then
+		j = not actor.FGArm and 1 or (not actor.BGArm and 2 or j)
+	elseif isLeg then
+		j = not actor.FGLeg and 3 or (not actor.BGLeg and 4 or j)
+	elseif isHead and actor.Head == nil then
+		j = 5
+	end
+	if j ~= 0 then
+		local reference = CreateAHuman(actor:GetModuleAndPresetName())
+		local referenceLimb
+		if j == 1 then
+			referenceLimb = reference.FGArm
+		elseif j == 2 then
+			referenceLimb = reference.BGArm
+		elseif j == 3 then
+			referenceLimb = reference.FGLeg
+		elseif j == 4 then
+			referenceLimb = reference.BGLeg
+		elseif j == 5 then
+			referenceLimb = reference.Head
+		end
+		local newLimb
+		if isArm then
+			newLimb = CreateArm(limbName .. (j == 1 and " FG" or " BG"))
+		elseif isLeg then
+			newLimb = CreateLeg(limbName .. (j == 3 and " FG" or " BG"))
+		else
+			newLimb = limb:Clone() --(limbName);
+		end
+		if newLimb then
+			if referenceLimb then
+				newLimb.ParentOffset = referenceLimb.ParentOffset
+				local woundName = referenceLimb:GetEntryWoundPresetName()
+				if woundName ~= "" then
+					newLimb.ParentBreakWound = CreateAEmitter(woundName)
+				end
+			end
+			for wound in newLimb.Wounds do
+				if
+					math.floor(wound.ParentOffset.X - newLimb.JointOffset.X + 0.5) == 0
+					and math.floor(wound.ParentOffset.Y - newLimb.JointOffset.Y + 0.5) == 0
+				then
+					for em in wound.Emissions do
+						em.ParticlesPerMinute = 0
+					end
+					wound.Scale = wound.Scale * 0.7
+				end
+			end
+			if j == 1 then
+				actor.FGArm = newLimb
+			elseif j == 2 then
+				actor.BGArm = newLimb
+			elseif j == 3 then
+				actor.FGLeg = newLimb
+			elseif j == 4 then
+				actor.BGLeg = newLimb
+			elseif j == 5 then
+				actor.Head = newLimb
+			end
+			for wound in actor.Wounds do
+				if
+					math.floor(wound.ParentOffset.X - newLimb.ParentOffset.X + 0.5) == 0
+					and math.floor(wound.ParentOffset.Y - newLimb.ParentOffset.Y + 0.5) == 0
+				then
+					for em in wound.Emissions do
+						em.ParticlesPerMinute = 0
+					end
+					wound.Scale = wound.Scale * 0.7
+				end
+			end
+			limb:RemoveNumberValue("Carriable")
+		else
+			j = 0
+		end
+		DeleteEntity(reference)
+	end
+	return j ~= 0
+end
+-----------------------------------------------------------------------------------------
+--
+-----------------------------------------------------------------------------------------
 function CF_RandomizeLimbs(actor, limbs)
 	if IsAHuman(actor) then
 		actor = ToAHuman(actor)

--- a/VoidWanderers.rte/Scripts/Panel_Clones.lua
+++ b/VoidWanderers.rte/Scripts/Panel_Clones.lua
@@ -438,7 +438,7 @@ function VoidWanderers:ProcessClonesControlPanelUI()
 												if itm ~= nil then
 													if
 														itm:HasScript(CF_ModuleName .. "/Items/Limb.lua")
-														and CF_AttemptReplaceLimb(itm, a)
+														and CF_AttemptReplaceLimb(a, itm)
 													then
 														DeleteEntity(itm)
 													else

--- a/VoidWanderers.rte/Scripts/StrategyScreenMain.lua
+++ b/VoidWanderers.rte/Scripts/StrategyScreenMain.lua
@@ -96,7 +96,7 @@ function VoidWanderers:StartActivity()
 				MovableMan:AddActor(brn)
 				self:SetPlayerBrain(brn, plr)
 				self:SwitchToActor(brn, plr, Activity.TEAM_1)
-				CameraMan:SetScrollTarget(brn.Pos, 0.04, false, self:ScreenOfPlayer(plr))
+				CameraMan:SetScrollTarget(brn.Pos, 0.04, self:ScreenOfPlayer(plr))
 
 				--brn.Team = -1;
 


### PR DESCRIPTION
CF_AttemptReplaceLimb was referenced in a few places as though it were global, which it wasn't, so I put it in the most appropriate library I could think of, and rearranged it's parameters to be better in line with it's new neighbors. Also required the library in the Limb.lua so that it'd actually gain access to it.

SplitScreen also wasn't working because of seven characters in StrategyScreenMain.lua, specifically the CameraMan SetScrollTarget call on line ninety-nine had an extra boolean parameter that apparently wasn't in use in the current release, which caused an error that repeatedly fatally failed the game initiation process.